### PR TITLE
비밀번호 암호화 추가, member 테이블에 insert 및 테스트코드 추가

### DIFF
--- a/src/main/java/com/hanamarket/config/security/SecurityConfig.java
+++ b/src/main/java/com/hanamarket/config/security/SecurityConfig.java
@@ -1,0 +1,43 @@
+package com.hanamarket.config.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfiguration;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@RequiredArgsConstructor
+@EnableWebSecurity
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public WebSecurityCustomizer configure() {
+        return web -> web.ignoring()
+                .requestMatchers("/**");
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable);
+        http
+                .authorizeHttpRequests(
+                        authorize -> authorize
+                                .requestMatchers("/**").permitAll()
+                                .anyRequest().authenticated()
+                );
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/hanamarket/login/application/error/LoginApplicationError.java
+++ b/src/main/java/com/hanamarket/login/application/error/LoginApplicationError.java
@@ -9,7 +9,9 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum LoginApplicationError implements ErrorCode {
     VALIDATE_EMAIL("LOGIN_A001", "이메일 형식에 맞지않습니다."),
-    VALIDATE_PASSWORD("LOGIN_A002", "비밀번호는 최소 8자 이상입니다."),;
+    VALIDATE_PASSWORD("LOGIN_A002", "비밀번호는 최소 8자 이상입니다."),
+    DUPLICATE_EMAIL_ERROR("LOGIN_A003", "이미 존재하는 email 입니다."),
+    ;
 
     String code;
     String message;

--- a/src/main/java/com/hanamarket/login/application/impl/LoginApplicationServiceImpl.java
+++ b/src/main/java/com/hanamarket/login/application/impl/LoginApplicationServiceImpl.java
@@ -11,12 +11,14 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 @Slf4j
 public class LoginApplicationServiceImpl implements LoginApplicationService {
 
@@ -27,8 +29,9 @@ public class LoginApplicationServiceImpl implements LoginApplicationService {
     private static final Pattern passwordPattern = Pattern.compile(PASSWORD_REGEX);
 
     private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
 
-
+    @Transactional
     @Override
     public void register(RegisterCommand registerCommand) {
         if (!isValidEmail(registerCommand.email())) {
@@ -41,9 +44,11 @@ public class LoginApplicationServiceImpl implements LoginApplicationService {
 
         Member member = Member.builder()
                 .email(registerCommand.email())
-                .password(registerCommand.password())
+                .password(passwordEncoder.encode(registerCommand.password())) // password 암호화
                 .nickname(registerCommand.nickname())
                 .build();
+
+        log.info("member : {}", member);
 
         memberRepository.save(member);
     }

--- a/src/main/java/com/hanamarket/login/domain/Member.java
+++ b/src/main/java/com/hanamarket/login/domain/Member.java
@@ -12,6 +12,7 @@ import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Getter
 @NoArgsConstructor
@@ -19,6 +20,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @EqualsAndHashCode(of = {"id"}, callSuper = false)
 @Entity
+@ToString
 @Table(name = "MEMBER")
 public class Member extends Audit {
 

--- a/src/main/java/com/hanamarket/login/domain/repository/MemberRepository.java
+++ b/src/main/java/com/hanamarket/login/domain/repository/MemberRepository.java
@@ -4,4 +4,5 @@ import com.hanamarket.login.domain.Member;
 import org.springframework.data.repository.CrudRepository;
 
 public interface MemberRepository extends CrudRepository<Member, Long> {
+    Boolean existsMemberByEmail(String email);
 }

--- a/src/test/java/com/hanamarket/login/application/LoginApplicationServiceTest.java
+++ b/src/test/java/com/hanamarket/login/application/LoginApplicationServiceTest.java
@@ -1,5 +1,6 @@
 package com.hanamarket.login.application;
 
+import com.hanamarket.common.exception.MarketRuntimeException;
 import com.hanamarket.login.application.command.RegisterCommand;
 import com.hanamarket.login.domain.Member;
 import com.hanamarket.login.infrastructure.dto.RegisterRequest;
@@ -35,7 +36,7 @@ class LoginApplicationServiceTest {
 
         // when
         // then
-        assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> loginApplicationService.register(command));
+        assertThatExceptionOfType(MarketRuntimeException.class).isThrownBy(() -> loginApplicationService.register(command));
     }
 
     @Test
@@ -46,6 +47,6 @@ class LoginApplicationServiceTest {
 
         // when
         // then
-        assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> loginApplicationService.register(command));
+        assertThatExceptionOfType(MarketRuntimeException.class).isThrownBy(() -> loginApplicationService.register(command));
     }
 }

--- a/src/test/java/com/hanamarket/login/application/LoginApplicationServiceTest.java
+++ b/src/test/java/com/hanamarket/login/application/LoginApplicationServiceTest.java
@@ -1,0 +1,51 @@
+package com.hanamarket.login.application;
+
+import com.hanamarket.login.application.command.RegisterCommand;
+import com.hanamarket.login.domain.Member;
+import com.hanamarket.login.infrastructure.dto.RegisterRequest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class LoginApplicationServiceTest {
+
+    @Autowired
+    LoginApplicationService loginApplicationService;
+
+    @Test
+    void 회원가입_정상_처리() {
+        // given
+        RegisterRequest registerRequest = new RegisterRequest("eojin312@naver.com", "testPassword", "어진이");
+        RegisterCommand command = registerRequest.toCommand();
+
+        // when
+        loginApplicationService.register(command);
+    }
+
+    @Test
+    public void 회원가입_이메일_validation체크 () {
+        // given
+        RegisterRequest registerRequest = new RegisterRequest("eojin312", "testPassword", "어진이");
+        RegisterCommand command = registerRequest.toCommand();
+
+        // when
+        // then
+        assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> loginApplicationService.register(command));
+    }
+
+    @Test
+    public void 회원가입_비밀번호_validation체크 () {
+        // given
+        RegisterRequest registerRequest = new RegisterRequest("eojin312@naver.com", "test", "어진이");
+        RegisterCommand command = registerRequest.toCommand();
+
+        // when
+        // then
+        assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> loginApplicationService.register(command));
+    }
+}

--- a/src/test/java/com/hanamarket/login/application/LoginApplicationServiceTest.java
+++ b/src/test/java/com/hanamarket/login/application/LoginApplicationServiceTest.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.util.Random;
+
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -21,7 +23,7 @@ class LoginApplicationServiceTest {
     @Test
     void 회원가입_정상_처리() {
         // given
-        RegisterRequest registerRequest = new RegisterRequest("eojin312@naver.com", "testPassword", "어진이");
+        RegisterRequest registerRequest = new RegisterRequest(randomEmail() + "@naver.com", "testPassword", "어진이");
         RegisterCommand command = registerRequest.toCommand();
 
         // when
@@ -29,7 +31,17 @@ class LoginApplicationServiceTest {
     }
 
     @Test
-    public void 회원가입_이메일_validation체크 () {
+    void 회원가입_이메일_중복체크 () {
+        // given
+        RegisterRequest registerRequest = new RegisterRequest("eojin312@naver.com", "testPassword", "어진이");
+        RegisterCommand command = registerRequest.toCommand();
+
+        // when & then
+        assertThatExceptionOfType(MarketRuntimeException.class).isThrownBy(() -> loginApplicationService.register(command));
+    }
+
+    @Test
+    void 회원가입_이메일_validation체크 () {
         // given
         RegisterRequest registerRequest = new RegisterRequest("eojin312", "testPassword", "어진이");
         RegisterCommand command = registerRequest.toCommand();
@@ -40,7 +52,7 @@ class LoginApplicationServiceTest {
     }
 
     @Test
-    public void 회원가입_비밀번호_validation체크 () {
+    void 회원가입_비밀번호_validation체크 () {
         // given
         RegisterRequest registerRequest = new RegisterRequest("eojin312@naver.com", "test", "어진이");
         RegisterCommand command = registerRequest.toCommand();
@@ -48,5 +60,19 @@ class LoginApplicationServiceTest {
         // when
         // then
         assertThatExceptionOfType(MarketRuntimeException.class).isThrownBy(() -> loginApplicationService.register(command));
+    }
+
+    public String randomEmail() {
+        int length = 5;
+        String characters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890";
+        StringBuilder randomString = new StringBuilder();
+
+        Random random = new Random();
+        for (int i = 0; i < length; i++) {
+            int index = random.nextInt(characters.length());
+            randomString.append(characters.charAt(index));
+        }
+
+        return randomString.toString();
     }
 }


### PR DESCRIPTION
## 개요
역시 spring security 는 어려워요 ㅠㅠ
이번에 springboot 가 3.x 로 올라가면서
3.x 버전에 호환되는 spring security 가 import 되니..
기존 우리가 알던 SecurityConfig 로 구성하면 deprecated 되었다고 뜹니다.
이참에 사이드하면서 알게된 거, 유용하게 씁시다~

아 아직 로그인이 완성되지않아서, 모든 권한 다 열어두었습니다

## 작업상세
- 비밀번호 암호화 추가, 
- 회원가입 시, member 정보 insert
- 회원가입 테스트코드 작성
- springSecurity config 추가


## TODO
- login
- JWT
- email 발송 및 인증
- member 컬럼에 status? role? 추가 